### PR TITLE
client-ffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "runtime",
     "utils",
     "client",
+    "client-ffi",
     "node",
 ]
 

--- a/client-ffi/Cargo.toml
+++ b/client-ffi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "keystore-ffi"
+version = "0.1.0"
+authors = ["Amar Singh <asinghchrony@protonmail.com>, Shady Khalifa <shekohex@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+ffi_helpers = "0.1.0"
+ipfs-embed = "0.1.0"
+ipld-block-builder = "0.3.0"
+sled = "0.32.0-rc1"
+keystore = {package = "keybase-keystore", git = "https://github.com/sunshine-protocol/substrate-identity"}
+keystore-ffi = {package = "keystore-ffi", git = "https://github.com/sunshine-protocol/substrate-identity"}
+client = { package = "sunshine-client", path = "../client" }
+
+[build-dependencies]
+cbindgen = "0.14.0"

--- a/client-ffi/src/lib.rs
+++ b/client-ffi/src/lib.rs
@@ -1,0 +1,53 @@
+#![allow(clippy::missing_safety_doc)]
+
+use ffi_helpers::null_pointer_check;
+use client::{ClientBuilder, Error, Runtime, SunClient};
+use keystore_ffi::*;
+use std::{
+    ffi::{CStr, CString},
+    os::raw,
+    path::Path,
+};
+
+// #[no_mangle]
+// pub unsafe extern "C" fn client_builder_new() -> *mut raw::c_void {
+//     // can I use this from `keystore_ffi` like this?
+//     let new_client = ClientBuilder::new().build().await.unwrap();
+//     let sun_client = SunClient::new();
+//     let boxed_sunshine_client = Box::new(sun_client);
+//     Box::into_raw(boxed_sunshine_client) as *mut _
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn open_sled_ipld_tree() -> *mut raw::c_void {
+//     // can I use this from `keystore_ffi` like this?
+//     let new_client = ClientBuilder::new().build().await.unwrap();
+//     let sun_client = SunClient::new();
+//     let boxed_sunshine_client = Box::new(sun_client);
+//     Box::into_raw(boxed_sunshine_client) as *mut _
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn new_block_builder() -> *mut raw::c_void {
+//     // can I use this from `keystore_ffi` like this?
+//     let new_client = ClientBuilder::new().build().await.unwrap();
+//     let sun_client = SunClient::new();
+//     let boxed_sunshine_client = Box::new(sun_client);
+//     Box::into_raw(boxed_sunshine_client) as *mut _
+// }
+
+// #[no_mangle]
+// pub unsafe extern "C" fn client_new() -> *mut raw::c_void {
+//     // can I use this from `keystore_ffi` like this?
+//     let keystore = keystore_new();
+//     // TODO
+//     let subxt = client_builder_new();
+//     // TODO
+//     let db_store = open_sled_ipld_tree();
+//     // TODO
+//     let ipld = new_block_builder(db_store); // w/ Codec::new()
+//     // TODO: initialize keystore
+//     let sun_client = SunClient::new(subxt, keystore, ipld);
+//     let boxed_sunshine_client = Box::new(sun_client);
+//     Box::into_raw(boxed_sunshine_client) as *mut _
+// }


### PR DESCRIPTION
doesnt compile because it doesnt recognize `keystore-ffi`

```
➜  client-ffi git:(master) ✗ carb
    Updating crates.io index
    Updating git repository `https://github.com/sunshine-protocol/substrate-identity`
error: no matching package named `keystore-ffi` found
location searched: https://github.com/sunshine-protocol/substrate-identity
required by package `keystore-ffi v0.1.0 (/Users/4meta5/sunshine-protocol/sunshine-node/client-ffi)`
```

and I don't want to copy paste the keystore code from keystore-ffi. I guess keybase-keystore is getting an update soon anyway so I'll step away from this for the time being...

@shekohex you should probably start with getting `dart-bindgen` to work with `substrate-identity` and @dvc94ch can get the client working in this repo #95 before we add the FFI